### PR TITLE
Zustand Context Refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-dom": "^18",
         "react-mosaic-component": "^6.1.0",
         "react-toastify": "^10.0.5",
-        "roslib": "^1.4.1"
+        "roslib": "^1.4.1",
+        "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -6943,6 +6944,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
+      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zustand/node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18",
     "react-mosaic-component": "^6.1.0",
     "react-toastify": "^10.0.5",
-    "roslib": "^1.4.1"
+    "roslib": "^1.4.1",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/components/Connect.tsx
+++ b/src/app/components/Connect.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { SyntheticEvent, useContext } from "react";
+import { SyntheticEvent } from "react";
 import ROSContext from "../contexts/ROSContext"; // Import the useROSInstanceState function
 import { useState, useEffect } from "react";
 import ConnectButton from "./ConnectButton";
 import { TextField, Grid, Paper, Box } from "@mui/material";
 
 import { useRouter } from "next/navigation";
-import RosConnect from "./ROSConnection";
 
 function Connect() {
   const router = useRouter();
@@ -23,7 +22,6 @@ function Connect() {
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
     if (address) {
-      localStorage.setItem("rosServerAddress", address);
       ros.connect(address, () => {
         // TO-DO: Page Navigation (use router.push())
       });
@@ -42,45 +40,45 @@ function Connect() {
   };
 
   return (
-      <Grid
-        container
-        justifyContent="center"
-        alignItems="center"
-        style={{ minHeight: "100vh" }}
-      >
-        <Grid item lg={4} md={6} sm={8}>
-          <Paper>
-            <Box p={1}>
-              <form onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
-                <Grid
-                  container
-                  direction="row"
-                  spacing={2}
-                  justifyContent="left"
-                  alignItems="center"
-                >
-                  <Grid item xs={9}>
-                    <TextField
-                      required
-                      fullWidth
-                      id="address"
-                      onChange={handleChange}
-                      value={address}
-                      label="Rover IP"
-                    />
-                  </Grid>
-                  <Grid item xs={3}>
-                    <ConnectButton
-                      connecting={ros.connection.isConnecting}
-                      connected={ros.connection.isConnected}
-                    />
-                  </Grid>
+    <Grid
+      container
+      justifyContent="center"
+      alignItems="center"
+      style={{ minHeight: "100vh" }}
+    >
+      <Grid item lg={4} md={6} sm={8}>
+        <Paper>
+          <Box p={1}>
+            <form onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+              <Grid
+                container
+                direction="row"
+                spacing={2}
+                justifyContent="left"
+                alignItems="center"
+              >
+                <Grid item xs={9}>
+                  <TextField
+                    required
+                    fullWidth
+                    id="address"
+                    onChange={handleChange}
+                    value={address}
+                    label="Rover IP"
+                  />
                 </Grid>
-              </form>
-            </Box>
-          </Paper>
-        </Grid>
+                <Grid item xs={3}>
+                  <ConnectButton
+                    connecting={ros.connection.isConnecting}
+                    connected={ros.connection.isConnected}
+                  />
+                </Grid>
+              </Grid>
+            </form>
+          </Box>
+        </Paper>
       </Grid>
+    </Grid>
   );
 }
 

--- a/src/app/components/Connect.tsx
+++ b/src/app/components/Connect.tsx
@@ -1,29 +1,31 @@
 "use client";
 
 import { SyntheticEvent, useContext } from "react";
-import ROSContext from "../contexts/ROSContext";
+import ROSContext from "../contexts/ROSContext"; // Import the useROSInstanceState function
 import { useState, useEffect } from "react";
 import ConnectButton from "./ConnectButton";
 import { TextField, Grid, Paper, Box } from "@mui/material";
 
 import { useRouter } from "next/navigation";
+import RosConnect from "./ROSConnection";
 
 function Connect() {
   const router = useRouter();
-  const ros = useContext(ROSContext);
+  const ros = ROSContext.useROSStore();
 
   const [address, setAddress] = useState<string>("");
   useEffect(() => {
-    const defaultAddress = "ws://" + window.location.host.split(":")[0] + ":9090";
+    const defaultAddress =
+      "ws://" + window.location.host.split(":")[0] + ":9090";
     setAddress(defaultAddress);
-  }, [address])
+  }, [address]);
 
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
     if (address) {
       localStorage.setItem("rosServerAddress", address);
       ros.connect(address, () => {
-        router.replace('/dashboard');
+        // TO-DO: Page Navigation (use router.push())
       });
     }
   };
@@ -40,45 +42,45 @@ function Connect() {
   };
 
   return (
-    <Grid
-      container
-      justifyContent="center"
-      alignItems="center"
-      style={{ minHeight: "100vh" }}
-    >
-      <Grid item lg={4} md={6} sm={8}>
-        <Paper>
-          <Box p={1}>
-            <form onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
-              <Grid
-                container
-                direction="row"
-                spacing={2}
-                justifyContent="left"
-                alignItems="center"
-              >
-                <Grid item xs={9}>
-                  <TextField
-                    required
-                    fullWidth
-                    id="address"
-                    onChange={handleChange}
-                    value={address}
-                    label="Rover IP"
-                  />
+      <Grid
+        container
+        justifyContent="center"
+        alignItems="center"
+        style={{ minHeight: "100vh" }}
+      >
+        <Grid item lg={4} md={6} sm={8}>
+          <Paper>
+            <Box p={1}>
+              <form onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+                <Grid
+                  container
+                  direction="row"
+                  spacing={2}
+                  justifyContent="left"
+                  alignItems="center"
+                >
+                  <Grid item xs={9}>
+                    <TextField
+                      required
+                      fullWidth
+                      id="address"
+                      onChange={handleChange}
+                      value={address}
+                      label="Rover IP"
+                    />
+                  </Grid>
+                  <Grid item xs={3}>
+                    <ConnectButton
+                      connecting={ros.connection.isConnecting}
+                      connected={ros.connection.isConnected}
+                    />
+                  </Grid>
                 </Grid>
-                <Grid item xs={3}>
-                  <ConnectButton
-                    connecting={ros.connection.isConnecting}
-                    connected={ros.connection.isConnected}
-                  />
-                </Grid>
-              </Grid>
-            </form>
-          </Box>
-        </Paper>
+              </form>
+            </Box>
+          </Paper>
+        </Grid>
       </Grid>
-    </Grid>
   );
 }
 

--- a/src/app/components/ROSConnection.tsx
+++ b/src/app/components/ROSConnection.tsx
@@ -1,21 +1,13 @@
 "use client";
 
-import ROSContext, { ConnectionStatus } from "../contexts/ROSContext";
-import ROSLIB from "roslib";
-import { useState, useEffect, ReactNode, useContext } from "react";
+import ROSContext from "../contexts/ROSContext";
+import { useEffect } from "react";
 import { toast } from "react-toastify";
 import "react-toastify/ReactToastify.css";
 
-const defaultConnection: ConnectionStatus = {
-  url: "ws://localhost:9090",
-  isConnected: false,
-  isConnecting: false,
-};
-
-export default function ROSConnect({ children }: { children: ReactNode }) {
-  const [connection, setConnection] =
-    useState<ConnectionStatus>(defaultConnection);
-  const [ros] = useState<ROSLIB.Ros>(new ROSLIB.Ros({}));
+export default function RosConnect() : JSX.Element {
+  const { connection, setConnection } = ROSContext.useConnectionState();
+  const {ros, setConnect, setDisconnect} = ROSContext.useROSStore();
 
   useEffect(() => {
     const handleConnection = () => {
@@ -86,6 +78,9 @@ export default function ROSConnect({ children }: { children: ReactNode }) {
       }
     };
 
+    setConnect(connect);
+    setDisconnect(disconnect);
+    
     ros.on("connection", handleConnection);
 
     ros.on("error", handleError);
@@ -94,8 +89,8 @@ export default function ROSConnect({ children }: { children: ReactNode }) {
 
     return () => {
       ros.off("connection", handleConnection);
-      ros.off('close', handleClose);
-      ros.off('error', handleError);
+      ros.off("close", handleClose);
+      ros.off("error", handleError);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -136,16 +131,7 @@ export default function ROSConnect({ children }: { children: ReactNode }) {
     ros.close();
   };
 
-  return (
-    <ROSContext.Provider
-      value={{
-        connect: connect,
-        disconnect: disconnect,
-        ros: ros,
-        connection: connection,
-      }}
-    >
-      {children}
-    </ROSContext.Provider>
-  );
+
+
+  return <></>;
 }

--- a/src/app/components/TestSubscriber.tsx
+++ b/src/app/components/TestSubscriber.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect, useContext } from "react";
 import ROSLIB from "roslib";
 import ROSContext from "../contexts/ROSContext";
 import { String } from "../types/stdMsgTypes";
+import useROS from "../contexts/ROSContext";
 
 function Subscribe() : JSX.Element {
-  const ros = useContext(ROSContext);
+  const ros = ROSContext.useROSStore();
   const [msg, setMsg] = useState<string>("");
 
   const listener = new ROSLIB.Topic({

--- a/src/app/components/TestSubscriber.tsx
+++ b/src/app/components/TestSubscriber.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect } from "react";
 import ROSLIB from "roslib";
 import ROSContext from "../contexts/ROSContext";
 import { String } from "../types/stdMsgTypes";
-import useROS from "../contexts/ROSContext";
 
-function Subscribe() : JSX.Element {
+function Subscribe(): JSX.Element {
   const ros = ROSContext.useROSStore();
   const [msg, setMsg] = useState<string>("");
 
   const listener = new ROSLIB.Topic({
-    ros: (ros.ros as ROSLIB.Ros),
+    ros: ros.ros as ROSLIB.Ros,
     name: "/chatter",
     messageType: "std_msgs/String",
   });
@@ -19,7 +18,7 @@ function Subscribe() : JSX.Element {
   useEffect(() => {
     listener.subscribe((message) => setMsg((message as String).data));
     return () => listener.unsubscribe();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -1,15 +1,15 @@
 'ues client'
 
-import RosConnection from "../components/ROSConnection";
 import Connect from "../components/Connect";
 import { ToastContainer } from "react-toastify";
-import Subscribe from "../components/TestSubscriber";
+import RosConnect from "../components/ROSConnection";
 
 export default function ConnectPage() {
   return (
-    <RosConnection>
+    <>
+        <RosConnect></RosConnect>
         <ToastContainer />
         <Connect />
-    </RosConnection>
+    </>
   );
 }

--- a/src/app/contexts/ROSContext.tsx
+++ b/src/app/contexts/ROSContext.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { createContext } from "react";
+import { create } from "zustand";
+import ROSLIB from "roslib";
+import { disconnect } from "process";
 
 export interface ConnectionStatus {
   url: string;
@@ -9,12 +11,62 @@ export interface ConnectionStatus {
 }
 
 interface ROSConnection {
-  ros: ROSLIB.Ros | null;
+  ros: ROSLIB.Ros;
   connection: ConnectionStatus;
   connect: (url: string, callback: VoidFunction) => void;
   disconnect: () => void;
 }
 
-const ROSContext = createContext<ROSConnection>({} as ROSConnection);
+interface ROSConnectionState {
+  connection: ConnectionStatus;
+  setConnection: (newConnection: ConnectionStatus) => void;
+}
 
+interface ROSInstanceState {
+  ros: ROSLIB.Ros;
+  connection: ConnectionStatus;
+  connect: (url: string, callback: VoidFunction) => void;
+  disconnect: () => void;
+
+  setRos: (newRos: ROSLIB.Ros) => void;
+  setConnect: (
+    newConnect: (url: string, callback: VoidFunction) => void,
+  ) => void;
+  setDisconnect: (newDisconnect: () => void) => void;
+}
+
+const useConnectionState = create<ROSConnectionState>((set) => ({
+  connection: {
+    isConnected: false,
+    isConnecting: false,
+    url: "",
+  },
+  setConnection: (newConnection: ConnectionStatus) => set((state) => ({ connection: newConnection })),
+}));
+
+const useROSStore = create<ROSInstanceState>((set) => ({
+  ros: new ROSLIB.Ros({}),
+  connection: {
+    isConnected: false,
+    isConnecting: false,
+    url: "",
+  },
+  connect: (url: string, callback: VoidFunction) => {
+    // Implement your connect logic here
+  },
+  disconnect: () => {
+    // Implement your disconnect logic here
+  },
+  setRos: (newRos: ROSLIB.Ros) => {
+    set((state) => ({ ros: newRos }));
+  },
+  setConnect: (newConnect: (url: string, callback: VoidFunction) => void) => {
+    set((state) => ({ connect: newConnect }));
+  },
+  setDisconnect: (newDisconnect: () => void) => {
+    set((state) => ({ disconnect: newDisconnect }));
+  },
+}));
+
+const ROSContext = { useROSStore, useConnectionState};
 export default ROSContext;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ToastContainer } from "react-toastify";
 import RosConnection from "../components/ROSConnection";
 import Subscribe from "../components/TestSubscriber";
 import ROSContext from "../contexts/ROSContext";
@@ -7,9 +8,10 @@ import ROSContext from "../contexts/ROSContext";
 
 function Dashboard() {
     return (
-    <RosConnection>
+    <>
+        <ToastContainer/>
         <Subscribe/>
-    </RosConnection>
+    </>
     )
 }
 


### PR DESCRIPTION
Did a minor refactor where I removed the react context API and replaced it with something a little simpler to work with in a Next.js enviroment (Zustand.) Basically replacing all the state management with Zustand global state management as a lot of components reuse the state of the ROSLIB.Ros object. This will allow for future developers and maintainers to implement new topics with much more ease.